### PR TITLE
I've temporarily reverted the Gmail search query in `GmailRepository.…

### DIFF
--- a/app/src/main/java/com/example/abonekaptanmobile/data/repository/GmailRepository.kt
+++ b/app/src/main/java/com/example/abonekaptanmobile/data/repository/GmailRepository.kt
@@ -48,14 +48,14 @@ class GmailRepository @Inject constructor(private val gmailApi: GmailApi) {
         val processedMessageIds = mutableSetOf<String>()
 
         // TEST İÇİN BASİT SORGUDAN BAŞLAYALIM, SONRA ORİJİNALİNE DÖNEBİLİRİZ
-        // val query = "in:inbox -in:spam -in:trash"
-        // Log.d("GmailRepository", "Using query: $query")
+        val query = "in:inbox -in:spam -in:trash"
+        Log.d("GmailRepository", "Using query: $query")
 
         // Orijinal, daha karmaşık sorgu (testten sonra bunu açabilirsiniz):
-        val domainQueryPart = trustedSenderDomains.joinToString(" OR ") { "from:$it" }
-        val keywordQueryPart = positiveKeywords.joinToString(" OR ") // Tırnaksız daha fazla sonuç verir
-        val query = "($domainQueryPart OR $keywordQueryPart) -in:spam -in:trash"
-        Log.d("GmailRepository", "Using complex query: $query")
+        // val domainQueryPart = trustedSenderDomains.joinToString(" OR ") { "from:$it" }
+        // val keywordQueryPart = positiveKeywords.joinToString(" OR ") // Tırnaksız daha fazla sonuç verir
+        // val query = "($domainQueryPart OR $keywordQueryPart) -in:spam -in:trash"
+        // Log.d("GmailRepository", "Using complex query: $query")
 
         try {
             var limitReachedInOutermostLoop = false


### PR DESCRIPTION
…kt` to the simpler `in:inbox -in:spam -in:trash` version.

This will allow me to test other recent changes (increased email scan limit and lowered AI threshold) and to confirm that the issue of you receiving zero emails is isolated to the previously implemented complex query.

I'll revisit and fix the complex query later.