### PR TITLE
Fix Hugging Face API authentication

### DIFF
--- a/app/src/main/java/com/example/abonekaptanmobile/di/AppModule.kt
+++ b/app/src/main/java/com/example/abonekaptanmobile/di/AppModule.kt
@@ -28,6 +28,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.io.IOException
 import java.util.concurrent.TimeUnit
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -44,9 +45,10 @@ object AppModule {
 
     @Singleton
     @Provides
+    @Named("GmailOkHttpClient")
     fun provideOkHttpClient(authManager: GoogleAuthManager): OkHttpClient {
         val loggingInterceptor = HttpLoggingInterceptor { message ->
-            Log.d("OkHttp", message)
+            Log.d("OkHttp_Gmail", message)
         }.apply {
             level = HttpLoggingInterceptor.Level.BODY
         }
@@ -83,7 +85,7 @@ object AppModule {
 
     @Singleton
     @Provides
-    fun provideGmailApi(okHttpClient: OkHttpClient): GmailApi {
+    fun provideGmailApi(@Named("GmailOkHttpClient") okHttpClient: OkHttpClient): GmailApi {
         return Retrofit.Builder()
             .baseUrl("https://www.googleapis.com/")
             .client(okHttpClient)
@@ -145,7 +147,25 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideHuggingFaceApi(okHttpClient: OkHttpClient): HuggingFaceApi {
+    @Named("HuggingFaceOkHttpClient")
+    fun provideHuggingFaceOkHttpClient(): OkHttpClient {
+        val loggingInterceptor = HttpLoggingInterceptor { message ->
+            Log.d("OkHttp_HF", message)
+        }.apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+        return OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideHuggingFaceApi(@Named("HuggingFaceOkHttpClient") okHttpClient: OkHttpClient): HuggingFaceApi {
         return Retrofit.Builder()
             .baseUrl("https://api-inference.huggingface.co/")
             .client(okHttpClient)


### PR DESCRIPTION
This commit resolves the HTTP 401 errors when calling the Hugging Face API by providing a separate OkHttpClient for HuggingFaceApi.

Previously, a single OkHttpClient was used for both Gmail and Hugging Face APIs. This client had an interceptor that added a Google OAuth2 token to all requests, which is incorrect for Hugging Face API calls and resulted in authentication failures.

Changes made in `AppModule.kt`:
- The original `OkHttpClient` provider (now named "GmailOkHttpClient") is used exclusively for `GmailApi`. It retains the Google AuthInterceptor.
- A new `OkHttpClient` provider (named "HuggingFaceOkHttpClient") was added. This client does *not* include the Google AuthInterceptor.
- `provideHuggingFaceApi` was updated to use this new "HuggingFaceOkHttpClient".

This allows the `HuggingFaceRepository` to use its hardcoded `AUTH_TOKEN` (Bearer hf_...) for Hugging Face API calls without it being overridden by the Gmail OAuth token.