### PR TITLE
Fix: Add JVM arguments to resolve Kapt IllegalAccessError

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,3 +30,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# JVM arguments for Kapt
+kapt.jvm.args=--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
Added --add-exports for necessary jdk.compiler packages to kapt.jvm.args in gradle.properties.

This resolves the error:
java.lang.IllegalAccessError: superclass access check failed: class org.jetbrains.kotlin.kapt3.base.javac.KaptJavaCompiler cannot access class com.sun.tools.javac.main.JavaCompiler because module jdk.compiler does not export com.sun.tools.javac.main.

This issue typically occurs when using Kapt with JDK 9+ due to the Java Platform Module System (JPMS) restricting access to internal JDK APIs. These arguments explicitly grant Kapt access to the required compiler internals.